### PR TITLE
Fix hotel price extraction for non-$ currencies and discounted rates

### DIFF
--- a/fast_hotels/core.py
+++ b/fast_hotels/core.py
@@ -180,10 +180,14 @@ def parse_response(
         price = None
         import re
         card_text = card.text(strip=True)
-        price_matches = re.findall(r'\$([0-9,.]+)', card_text)
+        price_matches = re.findall(r'[$₹£€]\s?([0-9][0-9,.]*)', card_text)
         if price_matches:
             try:
-                price = float(price_matches[0].replace(',', ''))
+                parsed_prices = [float(p.replace(',', '')) for p in price_matches]
+                # When a discount is shown, Google renders both the original
+                # (crossed-out) and current price; the current price is the
+                # lower of the two, so take the minimum rather than the first match.
+                price = min(parsed_prices)
             except Exception:
                 price = None
         if name and price is not None:
@@ -197,7 +201,7 @@ def parse_response(
     if not hotels:
         # Fallback: try to extract any hotel-like data from the HTML
         import re
-        price_pattern = r'\$(\d+(?:,\d+)?)'
+        price_pattern = r'[$₹£€]\s?(\d[\d,]*(?:\.\d+)?)'
         prices = re.findall(price_pattern, r.text)
         name_pattern = r'<h2[^>]*>([^<]+)</h2>'
         names = re.findall(name_pattern, r.text)


### PR DESCRIPTION
## Summary
- Price scraping in `parse_response` only matched the `$` symbol, so listings priced in other currencies (e.g. `₹` for India) returned zero matches and silently fell back to a broken whole-page fallback parser that misattributed star ratings as prices.
- Switched to taking the minimum of matched currency amounts per card, since discount listings render both the crossed-out original price and the current price, and the code previously always took the first match (often the higher, original price).

## Test plan
- [x] Ran existing test suite (`pytest tests/test_fast_hotels.py`) — passes
- [x] Manually queried a live Goa, India hotel search (INR pricing) before/after the fix and confirmed correct rupee prices are now extracted instead of garbage values pulled from star ratings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotel price detection to handle more currencies and pricing formats.
  * Better handles listings that show both original and discounted prices by using the lowest parsed price.
  * Expanded fallback parsing so hotel-like results are captured more reliably when no hotels are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->