### PR TITLE
Harden release and redirect checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
   push:
-    branches:
-      - '**'
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -15,13 +15,16 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1 
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          password: ${{ secrets.PYPI_API_KEY }} 
+          password: ${{ secrets.PYPI_API_KEY }}

--- a/fast_hotels/local_playwright.py
+++ b/fast_hotels/local_playwright.py
@@ -1,5 +1,7 @@
 from typing import Any
 import asyncio
+from urllib.parse import urlsplit
+
 from playwright.async_api import async_playwright
 
 async def fetch_with_playwright(url: str) -> str:
@@ -8,7 +10,8 @@ async def fetch_with_playwright(url: str) -> str:
         browser = await p.chromium.launch()
         page = await browser.new_page()
         await page.goto(url)
-        if page.url.startswith("https://consent.google.com"):
+        consent_url = urlsplit(page.url)
+        if consent_url.scheme == "https" and consent_url.hostname == "consent.google.com":
             await page.click('text="Accept all"')
         locator = page.locator('div.x2A2jf, div.GIPbOc.sSHqwe')
         await locator.wait_for()
@@ -28,4 +31,4 @@ def local_playwright_fetch(params: dict) -> Any:
         text = body
         text_markdown = body
 
-    return DummyResponse 
+    return DummyResponse


### PR DESCRIPTION
## Summary\n\n- validate the exact HTTPS Google consent hostname\n- publish packages from main only through the PyPI environment\n- pin all third-party actions and disable persisted checkout credentials\n\n## Verification\n\n- python3 -m py_compile fast_hotels/local_playwright.py\n- git diff --check\n\nCloses #5