### PR TITLE
Separate package build and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,7 @@
-name: Python package CI
+name: Publish Python distribution to PyPI
 
 on:
-  push:
-    branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,8 +10,9 @@ env:
   PYTHON_VERSION: '3.x'
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -24,4 +22,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: pip install build
       - run: python -m build
-      - run: python -m pip install dist/*.whl
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          password: ${{ secrets.PYPI_API_KEY }}


### PR DESCRIPTION
## Summary

- run package build validation on main, dev, and pull requests
- move PyPI publication into a separate manual, environment-gated workflow
- retain read-only permissions, immutable action SHAs, and non-persistent checkout credentials

## Verification

- both workflow files parse as YAML
- the prior main run built version 0.2.2 successfully and failed only because PyPI correctly rejected the existing file
- no new distribution was published

Closes #5